### PR TITLE
feat(amet): Add support for container customization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,8 +63,12 @@ RUN groupadd $username && \
 WORKDIR /home/$username
 USER $username:$username
 
+# RUN USER CUSTOMIZATIONS
+COPY ./.amet-customizer.sh /customizer.sh
+RUN sh -c /customizer.sh
+
 # STARTUP
-COPY ./key.pub /etc/ssh/$username/authorized_keys
+COPY ./.amet-key.pub /etc/ssh/$username/authorized_keys
 COPY ./homesync.sh /
 COPY ./entrypoint.sh /
 ENTRYPOINT [ "/entrypoint.sh" ]


### PR DESCRIPTION
I didn't love the idea of customizing the Amet container by editing the Dockerfile, because then you're wrestling with conflicts when you want to update Amet. So it occurred to me that we could let people customize the resulting container by specifying a script that the Dockerfile will COPY in and RUN at build time, under the target user's permissions. This is useful not only for installing language support and other tooling that you need for your particular development flow, but also to backfill dependencies on items we're syncing in the home folder.

Example: My dotfiles installer compiles a vim plugin that depends on python, python-dev, and cmake. I run the installer, it gets those deps, compiles the package, stores it in ~/.vim. ~/.vim syncs to the host machine, so now I can trash my container and rebuild it and my ~/.vim folder syncs back in. But uh-oh, now I have a binary in my container that no longer has the dependencies it was compiled against because they live outside of the home folder. If I `sudo apt-get install -y` those dependencies in my customizer script, though, they get re-added every time I build and I never have a problem. Boom.