### PR TITLE
feat(amet): Mount home on Linux using host UID/GID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ ARG timezone=UTC
 ARG lang=en_US.UTF-8
 ARG syncFreq=900
 ARG fsEngine=aufs
+ARG groupname=$username
+ARG userUid=1000
+ARG userGid=1000
 
 ENV DEV_USERNAME $username
 ENV DEV_PASSWORD $password
@@ -48,10 +51,11 @@ RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
    service docker start
 
 # CREATE USER
-RUN groupadd $username && \
+RUN groupadd $groupname -g $userGid && \
    useradd \
       -ms $DEV_SHELL \
-      -g $username \
+      -u $userUid \
+      -g $groupname \
       -p "$(openssl passwd -1 $DEV_PASSWORD)" \
       $username && \
    usermod -a -G docker,root $username && \
@@ -61,7 +65,7 @@ RUN groupadd $username && \
 
 # SWITCH TO USER. EVERYTHING BEYOND THIS POINT WILL BE DONE WITH USER'S UID/GID
 WORKDIR /home/$username
-USER $username:$username
+USER $username:$groupname
 
 # RUN USER CUSTOMIZATIONS
 COPY ./.amet-customizer.sh /customizer.sh


### PR DESCRIPTION
So the syncing is officially kooky dukes. Now that my home folder is developed and large, the initial sync operation on container start takes over an hour. Occasionally the container will completely freeze when it has the scheduled sync back to host.

I'd like to find a better solution for this on Mac when I get back to testing local mac deployments, but while I'm still on a remote Linux box, here's my solution. It doesn't matter what we name the user or the primary group in the container. As long as we create that user/group under the active UID/GID numbers being used on the host, there's never an ownership or permission issue. The container will see the files owned by the container user, host will see it owned by the host user, no chmodding or chowning necessary, ever.

So on mac, we mount home to /sync. The entrypoint sees that /sync exists and runs the homesync script how it has been. On Linux, we mount home to /home/$username and don't run the rsync anymore. Boom.